### PR TITLE
Improve fake console and logger

### DIFF
--- a/src/AppM.purs
+++ b/src/AppM.purs
@@ -12,7 +12,7 @@ import Routing.Duplex as RD
 import Routing.Hash as RH
 
 import App.Capability.Navigate (class MonadNavigate, navigate)
-import App.Capability.Log (class MonadLog, logMessage)
+import App.Capability.Log (class MonadLog)
 import App.Capability.Resource.User (class MonadUser)
 import App.Data.Username (Username)
 import App.Data.Profile (Profile)

--- a/src/AppM.purs
+++ b/src/AppM.purs
@@ -12,6 +12,7 @@ import Routing.Duplex as RD
 import Routing.Hash as RH
 
 import App.Capability.Navigate (class MonadNavigate, navigate)
+import App.Capability.Log (class MonadLog, logMessage)
 import App.Capability.Resource.User (class MonadUser)
 import App.Data.Username (Username)
 import App.Data.Profile (Profile)
@@ -52,3 +53,8 @@ instance MonadUser AppM where
     let profile = { username }
     HSM.updateStore $ LoginUser profile
     pure (Just profile)
+
+instance MonadLog AppM where
+  logMessage :: String -> AppM Unit
+  logMessage msg = do
+    HSM.updateStore $ UpdateMessageLog msg

--- a/src/Capability/Log.purs
+++ b/src/Capability/Log.purs
@@ -1,0 +1,20 @@
+-- | A logger capability whose `AppM` implementation will add another string to
+-- | the fake console rendered by the Router component. Just to keep the compl-
+-- | -exity down of this repo.
+
+-- | See comments in purescript-halogen-realworld's `Conduit.Capability.LogMessage` module:
+-- | https://github.com/thomashoneyman/purescript-halogen-realworld/blob/main/src/Capability/LogMessages.purs
+-- | and comments in:
+-- | https://github.com/thomashoneyman/purescript-halogen-realworld/blob/main/src/Data/Log.purs
+
+module App.Capability.Log where
+
+import Prologue
+
+import Halogen as H
+
+class Monad m <= MonadLog m where
+  logMessage :: String -> m Unit
+
+instance MonadLog m => MonadLog ( H.HalogenM state action slots msg m ) where
+  logMessage = H.lift <<< logMessage

--- a/src/Component/HTML/Navbar.purs
+++ b/src/Component/HTML/Navbar.purs
@@ -14,38 +14,51 @@ import App.Component.HTML.Util (navItem, whenElem)
             
 navbarPageWrapper
   :: forall w i r
-   . { currentUser :: Maybe Profile, changeLog :: Array String | r }
+   . { currentUser :: Maybe Profile, messageLog :: Array String | r }
   -> HH.HTML w i
   -> HH.HTML w i
-navbarPageWrapper { currentUser, changeLog } innerHtml =
-  HH.div_
-  [ HH.ul_
-    [ navItem Home "Home"
-    
-    , whenElem (isNothing currentUser) \_ ->
-        navItem Login "Log in"
-        
-    , whenElem (isJust currentUser) \_ ->
-        navItem Secrets "Secrets"
-   
-    ]
-  , HH.div_
-      [ innerHtml
-      , fakeConsole changeLog
-      ]
-  ]
+navbarPageWrapper { currentUser, messageLog } innerHtml =
+  HH.div
+    [ HP.style wrapperStyle ]
+    [ HH.div_ [ navbar, innerHtml ]
+    , HH.div_ [ HH.hr_, fakeConsole messageLog ]
+    ] 
   where
+    navbar :: HH.HTML w i
+    navbar =
+      HH.ul_
+        [ navItem Home "Home"
+
+        , whenElem (isNothing currentUser) \_ ->
+            navItem Login "Log in"
+
+        , whenElem (isJust currentUser) \_ ->
+            navItem Secrets "Secrets"
+        ]
+
     fakeConsole :: Array String -> HH.HTML w i
-    fakeConsole routeChangeLog =
+    fakeConsole messages =
       HH.div
-       -- I (Peter) kind of whatevered the CSS here.
-       -- Note to future self: stop reusing this.
-       -- Do better. Be better.
-       [ HP.style "margin-top: 300px; background: #282c34; color: #e06c75; padding-bottom: 200px"  ]
-       [ HH.hr_
-       , HH.div
-           [ HP.style "font-family: 'Consolas'; padding-left: 20px;" ]
-           [ HH.h2 [ HP.style "font-variant: small-caps;"  ] [ HH.text "Fake Console: " ]
-           , HH.ul_ $ map (\msg -> HH.li_ [ HH.text msg ]) routeChangeLog
-           ]
-       ]
+        [ HP.style consoleStyle  ]
+        [ HH.h2 [ HP.style "font-variant: small-caps;"  ] [ HH.text "Fake Console: " ]
+        , HH.ul_ $ map (\msg -> HH.li_ [ HH.text msg ]) messages
+        ]
+
+wrapperStyle :: String
+wrapperStyle = 
+  """
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: calc(100vh - 18px)
+  """
+
+consoleStyle :: String
+consoleStyle =
+  """
+  min-height: 275px;
+  background: #282c34;
+  color: #e06c75;
+  font-family: 'Consolas';
+  padding: 5px 20px 5px 20px;
+  """

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -22,7 +22,7 @@ main = HA.runHalogenAff do
   body <- HA.awaitBody
   
   let
-    initialStore = { currentUser: Nothing }
+    initialStore = { currentUser: Nothing, recentMessageLog: [] }
     routerInput = unit
     
   componentAff <- runAppM initialStore Router.component

--- a/src/Page/Login.purs
+++ b/src/Page/Login.purs
@@ -11,6 +11,7 @@ import Web.UIEvent.MouseEvent as MouseEvent
 
 import App.Capability.Navigate (class MonadNavigate)
 import App.Capability.Navigate as Navigate
+import App.Capability.Log (class MonadLog, logMessage)
 import App.Capability.Resource.User (class MonadUser)
 import App.Capability.Resource.User as User
 import App.Data.Username as Username
@@ -28,6 +29,7 @@ type Slot = H.Slot (Const Void) Void Unit
 component
   :: forall m q o
    . MonadEffect m
+  => MonadLog m
   => MonadNavigate m
   => MonadUser m
   => H.Component q Input o m
@@ -69,7 +71,9 @@ component =
         H.liftEffect $ Event.preventDefault (MouseEvent.toEvent mouseEvent)
         case Username.parse rawUsername of
           Nothing -> pure unit
-          Just username -> do
-            _ <- User.loginUser username
+          Just name -> do
+            _ <- User.loginUser name
+            logMessage $ "Signing in as user '" <> Username.toString name <> "'"
             shouldRedirect <- H.gets _.redirect
-            when shouldRedirect $ Navigate.navigate Home
+            when shouldRedirect do
+              Navigate.navigate Home

--- a/src/Page/Secrets.purs
+++ b/src/Page/Secrets.purs
@@ -14,6 +14,7 @@ import Web.UIEvent.MouseEvent as MouseEvent
 
 import App.Capability.Navigate (class MonadNavigate)
 import App.Capability.Navigate as Navigate
+import App.Capability.Log (class MonadLog, logMessage)
 import App.Capability.Resource.User (class MonadUser)
 import App.Component.HTML.Util (maybeElem)
 import App.Data.Username as Username
@@ -39,8 +40,9 @@ type Slot = H.Slot (Const Void) Void Unit
 component
   :: forall m q o
    . MonadStore Store.Action Store m
-  => MonadUser m
+  => MonadLog m
   => MonadNavigate m
+  => MonadUser m
   => H.Component q Input o m
 component =
   HSC.connect (HSS.selectEq _.currentUser) $ 
@@ -91,4 +93,5 @@ component =
         
       HandleLogout mouseEvent -> do
         H.liftEffect $ Event.preventDefault (MouseEvent.toEvent mouseEvent)
+        logMessage "Signing out"
         Navigate.logoutUser

--- a/src/Store.purs
+++ b/src/Store.purs
@@ -5,6 +5,7 @@ module App.Store where
 
 import Prologue
 
+import Data.Array as A
 import Control.Monad.State (class MonadState)
 import Halogen as H
 
@@ -12,11 +13,13 @@ import App.Data.Profile (Profile)
 
 type Store =
   { currentUser :: Maybe Profile
+  , recentMessageLog :: Array String
   }
 
 data Action
   = LoginUser Profile
   | LogoutUser
+  | UpdateMessageLog String
 
 reduce :: Store -> Action -> Store
 reduce store = case _ of
@@ -25,6 +28,16 @@ reduce store = case _ of
 
   LogoutUser ->
     store { currentUser = Nothing }
+  
+  UpdateMessageLog msg ->
+    let
+      -- Limits the nnumber of recent messages to 10
+      prependMessage :: String -> Array String -> Array String
+      prependMessage x xs
+        | A.length xs < 10 = x `A.cons` xs
+        | otherwise        = x `A.cons` (A.take 9 xs)
+    in
+      store { recentMessageLog = msg `prependMessage` store.recentMessageLog }
 
 -- | Helper used in the `Store`-connected components (`Router`, `Home`
 -- | and `Secrets`) to respond to changes in the global state


### PR DESCRIPTION
Abstracted out the logger so it'll work in any store-connected component. Kept it `String`-based (and so simpler than RWH's structured logging). 
1Improved the CSS around the "fake" rendered console that it logs to.