### PR TITLE
tooling and package set version bump (fixed minor breakage)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "private": true,
   "devDependencies": {
-    "parcel": "^2.3.2",
-    "purescript": "^0.14.7",
-    "spago": "^0.20.7"
+    "parcel": "^2.16.0",
+    "purescript": "^0.15.15",
+    "spago": "^0.21.0"
   },
   "scripts": {
     "build": "spago build",

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,6 +1,6 @@
 -- Modifications copyright (C) 2021 Peter Andersen
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.7-20220228/packages.dhall
-        sha256:585403682c9378a55da644fb2edbc74d2592d18283bc9fa3457ad79398bb55bb
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.15-20251014/packages.dhall
+        sha256:4637c0e749bf7775d790348bd88d4ee1f20634f14bbf237cddaf33b0ec712bbd
 
 in  upstream

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -35,4 +35,4 @@ main = HA.runHalogenAff do
   -- Listens to the route changes and tells the router component
   void $ liftEffect $ RH.matchesWith ( RD.parse routeCodec ) \mOld new ->
     when ( mOld /= Just new ) do
-      launchAff_ $ halogenIO.query $ H.mkTell $ Router.Navigate new   
+      launchAff_ $ void $ halogenIO.query $ H.mkTell $ Router.Navigate new   


### PR DESCRIPTION
Versions bumped to:
```json
"parcel": "^2.16.0",
"purescript": "^0.15.15",
"spago": "^0.21.0"
```
and corresponding package set of `psc-0.15.15-20251014`